### PR TITLE
Topic Cache Utility

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -108,7 +108,7 @@ func (s *Ensign) Shutdown() {
 // Reset the calls map and all associated handlers in preparation for a new test.
 func (s *Ensign) Reset() {
 	for key := range s.Calls {
-		s.Calls[key] = 0
+		delete(s.Calls, key)
 	}
 
 	s.OnPublish = nil

--- a/topics/cache.go
+++ b/topics/cache.go
@@ -1,0 +1,127 @@
+package topics
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	sdk "github.com/rotationalio/go-ensign"
+)
+
+const DefaultTimeout = 15 * time.Second
+
+var (
+	// TODO: move to dedicated errors package
+	ErrTopicNotFound = errors.New("topic with specified name does not exist")
+)
+
+// Cache manages topics on behalf of the user, looking up topicIDs by name and
+// cacheing them to prevent multiple remote requests. The cache should also wrap an
+// Ensign client but the cache uses the topic management functionality of the client, so
+// an independent interface is added to make testing simpler.
+type Cache struct {
+	topics map[string]string
+	client Client
+}
+
+type Client interface {
+	TopicExists(context.Context, string) (bool, error)
+	TopicID(context.Context, string) (string, error)
+	CreateTopic(context.Context, string) (string, error)
+}
+
+func NewCache(client Client) *Cache {
+	return &Cache{
+		topics: make(map[string]string),
+		client: client,
+	}
+}
+
+// Get returns a topicID from a topic; if the topic is not in the cache; an RPC call to
+// ensign is made to get and store the topic ID.
+func (t *Cache) Get(topic string) (topicID string, err error) {
+	var cached bool
+	if topicID, cached = t.topics[topic]; !cached {
+		// Fetch the topicID from Ensign
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+		defer cancel()
+
+		if topicID, err = t.client.TopicID(ctx, topic); err != nil {
+			if errors.Is(err, sdk.ErrTopicNameNotFound) {
+				return "", ErrTopicNotFound
+			}
+			return "", err
+		}
+
+		// Cache the topicID to prevent future RPC calls
+		t.topics[topic] = topicID
+	}
+	return topicID, nil
+}
+
+// Exists checks if the topic exists, first by checking the cache and if the topic is
+// not in the cache by performing an RPC call to ensign to check if the topic exists.
+func (t *Cache) Exists(topic string) (exists bool, err error) {
+	// Check if the topic is in the topic cache.
+	if _, exists = t.topics[topic]; exists {
+		return true, nil
+	}
+
+	// Otherwise make a request to Ensign to see if the topic exists
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	return t.client.TopicExists(ctx, topic)
+}
+
+// Ensure the topic exists by first performing a check if the topic exists and if it
+// doesn't, then creating the topic. The topicID of the created topic is cached to
+// prevent repeated calls to CreateTopic that will fail after the first call (topic
+// already exists error).
+func (t *Cache) Ensure(topic string) (topicID string, err error) {
+	var cached bool
+	if topicID, cached = t.topics[topic]; !cached {
+		// Fetch the topicID from Ensign
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+		defer cancel()
+
+		// TODO: this could probably be optimized using a call to TopicID and checking
+		// if the error is NotFound. The exists check is written here for clarity.
+		var exists bool
+		if exists, err = t.client.TopicExists(ctx, topic); err != nil {
+			return "", err
+		}
+
+		if !exists {
+			// NOTE: there is a race condition between the existence check and the
+			// create topic call (e.g. some other process could create the topic), which
+			// would result in an error being returned by CreateTopic. Better error
+			// handling would fix this case, since the user only needs the topic to be
+			// created and the topicID returned.
+			if topicID, err = t.client.CreateTopic(ctx, topic); err != nil {
+				// TODO: check ErrTopicAlreadyExists and return no error in this case.
+				return "", err
+			}
+		} else {
+			if topicID, err = t.client.TopicID(ctx, topic); err != nil {
+				return "", err
+			}
+		}
+
+		// Cache the topicID to prevent future RPC calls
+		t.topics[topic] = topicID
+	}
+	return topicID, nil
+}
+
+// Clear the topic cache resetting any internal cached state and refetching topic info.
+func (t *Cache) Clear() {
+	for key := range t.topics {
+		delete(t.topics, key)
+	}
+}
+
+// Length returns the number of items in the cache
+func (t *Cache) Length() int {
+	return len(t.topics)
+}

--- a/topics/cache_test.go
+++ b/topics/cache_test.go
@@ -1,0 +1,279 @@
+package topics_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	sdk "github.com/rotationalio/go-ensign"
+	api "github.com/rotationalio/go-ensign/api/v1beta1"
+	"github.com/rotationalio/go-ensign/mock"
+	. "github.com/rotationalio/go-ensign/topics"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
+)
+
+type topicTestSuite struct {
+	suite.Suite
+	mock  *mock.Ensign
+	cache *Cache
+}
+
+func (s *topicTestSuite) SetupSuite() {
+	assert := s.Assert()
+
+	// Create a new mock ensign server for each test (effectively resetting it)
+	s.mock = mock.New(nil)
+
+	// Create an sdk client that can be used as the topic client
+	client := &sdk.Client{}
+	err := client.ConnectMock(s.mock)
+	assert.NoError(err, "could not connect ensign client to mock")
+
+	// Create the cache for testing
+	s.cache = NewCache(client)
+}
+
+func (s *topicTestSuite) AfterTest(suiteName, testName string) {
+	// Cleanup the mock and the cache after testing.
+	s.mock.Reset()
+	s.cache.Clear()
+}
+
+func TestTopicsSuite(t *testing.T) {
+	suite.Run(t, &topicTestSuite{})
+}
+
+func (s *topicTestSuite) TestGet() {
+	// The topic cache should be empty to start and make a request to Ensign; after
+	// which point the topic name should be retrieved from the cache without an RPC.
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	// Have list topics return a list of topic names to search for the topicID
+	err := s.mock.UseFixture(mock.TopicNamesRPC, "testdata/topicnames.pb.json")
+	require.NoError(err, "could not load topic names fixture")
+
+	// The first lookup should make a request to the ensign mock
+	// Subsequent lookups should simply use the cache
+	for i := 0; i < 10; i++ {
+		topicID, err := s.cache.Get("testing.topics.topicb")
+		require.NoError(err, "could not lookup topic id")
+		require.Equal("01GWM936SNSN36JKTMSF9Q3N8B", topicID, "unexpected topicId returned")
+	}
+
+	require.Equal(1, s.cache.Length(), "expected cache to only have one item")
+	require.Equal(1, s.mock.Calls[mock.TopicNamesRPC], "expected the RPC to be called only once")
+	require.Len(s.mock.Calls, 1, "expected only one RPC called")
+
+	// A lookup to another topic should not cause the cache to fail
+	for i := 0; i < 10; i++ {
+		topicID, err := s.cache.Get("testing.topics.topica")
+		require.NoError(err, "could not lookup topic id")
+		require.Equal("01GWM89049D49FHJH81BT8795H", topicID, "unexpected topicId returned")
+	}
+
+	topicID, err := s.cache.Get("testing.topics.topicb")
+	require.NoError(err, "could not lookup topic id")
+	require.Equal("01GWM936SNSN36JKTMSF9Q3N8B", topicID, "unexpected topicId returned")
+
+	require.Equal(2, s.cache.Length(), "expected cache to only have one item")
+	require.Equal(2, s.mock.Calls[mock.TopicNamesRPC], "expected the RPC to be called only once")
+	require.Len(s.mock.Calls, 1, "expected only one RPC called")
+}
+
+func (s *topicTestSuite) TestGetFail() {
+	// Test errors returned from topic Get
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	// Test error returned from server
+	s.mock.UseError(mock.TopicNamesRPC, codes.DataLoss, "something bad happened")
+	_, err := s.cache.Get("testing.topics.topicc")
+	require.EqualError(err, "rpc error: code = DataLoss desc = something bad happened", "expected the error from the ensign server")
+
+	// Test not found in fixtures
+	err = s.mock.UseFixture(mock.TopicNamesRPC, "testdata/topicnames.pb.json")
+	require.NoError(err, "could not load topic names fixture")
+
+	_, err = s.cache.Get("testing.topics.does-not-exist")
+	require.ErrorIs(err, ErrTopicNotFound)
+
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+	require.Equal(2, s.mock.Calls[mock.TopicNamesRPC], "expected the RPC to be called only once")
+	require.Len(s.mock.Calls, 1, "expected only one RPC called")
+}
+
+func (s *topicTestSuite) TestExists() {
+	// Test the topic existence check functionality.
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	existingTopics := map[string]struct{}{
+		"testing.topics.topica": {},
+		"testing.topics.topicb": {},
+		"testing.topics.topicc": {},
+	}
+	s.mock.OnTopicExists = func(ctx context.Context, in *api.TopicName) (out *api.TopicExistsInfo, err error) {
+		out = &api.TopicExistsInfo{
+			Query: fmt.Sprintf("name=%q", in.Name),
+		}
+
+		_, out.Exists = existingTopics[in.Name]
+		return out, nil
+	}
+
+	for i := 0; i < 10; i++ {
+		exists, err := s.cache.Exists("testing.topics.topicb")
+		require.NoError(err, "could not call topic exists")
+		require.True(exists, "the topic should exist")
+
+		exists, err = s.cache.Exists("foo.bar.notreal")
+		require.NoError(err, "could not call topic exists")
+		require.False(exists, "the topic should not exist")
+	}
+
+	require.Equal(0, s.cache.Length(), "expected cache to be empty; nothing to cache on existence")
+	require.Equal(20, s.mock.Calls[mock.TopicExistsRPC], "expected the RPC to be called 20 times, for each existence check")
+	require.Len(s.mock.Calls, 1, "expected only one RPC called")
+}
+
+func (s *topicTestSuite) TestExistsCache() {
+	// Topic exists should return true if the topic is in the cache.
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	// Have list topics return a list of topic names to search for the topicID
+	err := s.mock.UseFixture(mock.TopicNamesRPC, "testdata/topicnames.pb.json")
+	require.NoError(err, "could not load topic names fixture")
+
+	s.cache.Get("testing.topics.topica")
+
+	exists, err := s.cache.Exists("testing.topics.topica")
+	require.NoError(err, "could not check existence of topics")
+	require.True(exists, "topic should exist in cache")
+
+	require.Equal(1, s.cache.Length(), "expected cache to contain one item")
+	require.Equal(1, s.mock.Calls[mock.TopicNamesRPC], "expected the topic names RPC to be called only once")
+	require.Equal(0, s.mock.Calls[mock.TopicExistsRPC], "expected the topic exists RPC to not be called")
+	require.Len(s.mock.Calls, 1, "expected only one RPC called")
+}
+
+func (s *topicTestSuite) TestExistsError() {
+	// An error should be returned if the RPC errors
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	s.mock.UseError(mock.TopicExistsRPC, codes.Internal, "something bad happened")
+
+	_, err := s.cache.Exists("testing.topics.topica")
+	require.EqualError(err, "rpc error: code = Internal desc = something bad happened")
+}
+
+func (s *topicTestSuite) TestEnsure() {
+	// The topic cache should be empty to start but populated with topic name to IDs to
+	// prevent multiple Ensign RPC calls. If the topic doesn't exist, it should be
+	// created.
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	existingTopics := map[string]struct{}{
+		"testing.topics.topica": {},
+		"testing.topics.topicb": {},
+		"testing.topics.topicc": {},
+	}
+	s.mock.OnTopicExists = func(ctx context.Context, in *api.TopicName) (out *api.TopicExistsInfo, err error) {
+		out = &api.TopicExistsInfo{
+			Query: fmt.Sprintf("name=%q", in.Name),
+		}
+
+		_, out.Exists = existingTopics[in.Name]
+		return out, nil
+	}
+
+	// Have list topics return a list of topic names to search for the topicID
+	err := s.mock.UseFixture(mock.TopicNamesRPC, "testdata/topicnames.pb.json")
+	require.NoError(err, "could not load topic names fixture")
+
+	// Have create topic return a unique topic
+	s.mock.OnCreateTopic = func(ctx context.Context, in *api.Topic) (*api.Topic, error) {
+		in.Id = ulid.Make().Bytes()
+		return in, nil
+	}
+
+	// The first lookup should make a request to the ensign mock
+	// Subsequent lookups should simply use the cache
+	for i := 0; i < 10; i++ {
+		topicID, err := s.cache.Ensure("testing.topics.topicb")
+		require.NoError(err, "could not lookup topic id")
+		require.Equal("01GWM936SNSN36JKTMSF9Q3N8B", topicID, "unexpected topicId returned")
+	}
+
+	require.Equal(1, s.cache.Length(), "expected cache to only have one item")
+	require.Equal(1, s.mock.Calls[mock.TopicNamesRPC], "expected the topic names RPC to be called only once")
+	require.Equal(1, s.mock.Calls[mock.TopicExistsRPC], "expected the topic exists RPC to be called only once")
+	require.Equal(0, s.mock.Calls[mock.CreateTopicRPC], "expected the create topic RPC to be called zero times")
+	require.Len(s.mock.Calls, 2, "expected two RPCs called")
+
+	// A lookup to a topic that does not exist should create the topic
+	for i := 0; i < 10; i++ {
+		topicID, err := s.cache.Ensure("testing.topics.foo")
+		require.NoError(err, "could not lookup topic id")
+		require.NotZero(topicID, "expected a ULID topic id to be returned")
+	}
+
+	require.Equal(2, s.cache.Length(), "expected cache to have two items")
+	require.Equal(1, s.mock.Calls[mock.TopicNamesRPC], "expected the topic names RPC to be called only once")
+	require.Equal(2, s.mock.Calls[mock.TopicExistsRPC], "expected the topic exists RPC to be called twice")
+	require.Equal(1, s.mock.Calls[mock.CreateTopicRPC], "expected the create topic RPC to be called zero times")
+	require.Len(s.mock.Calls, 3, "expected thre RPCs called")
+}
+
+func (s *topicTestSuite) TestEnsureCreateError() {
+	// The topic cache should be empty to start and make a request to Ensign; after
+	// which point the topic name should be retrieved from the cache without an RPC.
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	s.mock.OnTopicExists = func(context.Context, *api.TopicName) (*api.TopicExistsInfo, error) {
+		return &api.TopicExistsInfo{
+			Exists: false,
+		}, nil
+	}
+
+	s.mock.UseError(mock.CreateTopicRPC, codes.Internal, "couldn't create topic")
+
+	_, err := s.cache.Ensure("testing.topics.topica")
+	require.EqualError(err, "rpc error: code = Internal desc = couldn't create topic")
+}
+
+func (s *topicTestSuite) TestEnsureExistsError() {
+	// The topic cache should be empty to start and make a request to Ensign; after
+	// which point the topic name should be retrieved from the cache without an RPC.
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	s.mock.UseError(mock.TopicExistsRPC, codes.Internal, "topic hard to check")
+
+	_, err := s.cache.Ensure("testing.topics.topica")
+	require.EqualError(err, "rpc error: code = Internal desc = topic hard to check")
+}
+
+func (s *topicTestSuite) TestEnsureTopicIDError() {
+	// The topic cache should be empty to start and make a request to Ensign; after
+	// which point the topic name should be retrieved from the cache without an RPC.
+	require := s.Require()
+	require.Equal(0, s.cache.Length(), "expected cache to be empty")
+
+	s.mock.OnTopicExists = func(context.Context, *api.TopicName) (*api.TopicExistsInfo, error) {
+		return &api.TopicExistsInfo{
+			Exists: true,
+		}, nil
+	}
+
+	s.mock.UseError(mock.TopicNamesRPC, codes.Internal, "couldn't get topic id")
+
+	_, err := s.cache.Ensure("testing.topics.topica")
+	require.EqualError(err, "rpc error: code = Internal desc = couldn't get topic id")
+}

--- a/topics/testdata/topicnames.pb.json
+++ b/topics/testdata/topicnames.pb.json
@@ -1,0 +1,23 @@
+{
+  "topic_names": [
+    {
+      "topic_id": "01GWM89049D49FHJH81BT8795H",
+      "project_id": "01GTSMMC152Q95RD4TNYDFJGHT",
+      "name": "IdTcxHgZmlLM8oBj_YytLw",
+      "unhashed_name": "testing.topics.topica"
+    },
+    {
+      "topic_id": "01GWM936SNSN36JKTMSF9Q3N8B",
+      "project_id": "01GTSMMC152Q95RD4TNYDFJGHT",
+      "name": "F7x4fhbO4EhHVNDmBjMRIQ",
+      "unhashed_name": "testing.topics.topicb"
+    },
+    {
+      "topic_id": "01GWM994FPQJ7CMNXWAQGM4BC4",
+      "project_id": "01GTSMMC152Q95RD4TNYDFJGHT",
+      "name": "YuxuzM--ndLwlQX0kqnOBw",
+      "unhashed_name": "testing.topics.topicc"
+    }
+  ],
+	"next_page_token": ""
+}


### PR DESCRIPTION
### Scope of changes

Adds a topic name to ID cache mapping to prevent publishers and subscribers from having to repeated calls to the Ensign API to lookup topic IDs from a name.

Fixes SC-15574

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Is there a reason we might want to evict one entry from the cache rather than clearing it entirely? Probably this will not be used very much by users directly; but it would be good to think about how this might affect use. 

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [x]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?