### PR TITLE
Add per-call options

### DIFF
--- a/ensign.go
+++ b/ensign.go
@@ -178,7 +178,8 @@ func (c *Client) Subscribe(ctx context.Context, topics ...string) (_ Subscriber,
 // Ensure that the clone of the client is discarded and garbage collected after use;
 // the clone cannot be used to close the connection or fetch the options.
 //
-// Experimental
+// Experimental: call options and thread-safe cloning is an experimental feature and its
+// signature may be subject to change in the future.
 func (c *Client) WithCallOptions(opts ...grpc.CallOption) *Client {
 	// Return a clone of the client with the api interface and the opts but do not
 	// include the grpc connection to ensure only the original client can close it.

--- a/ensign_test.go
+++ b/ensign_test.go
@@ -159,7 +159,6 @@ func (s *sdkTestSuite) TestWithCallOptions() {
 			assert.NoError(err, "could not make info request from clone")
 		}
 	}()
-	// wg.Done()
 
 	go func() {
 		defer wg.Done()

--- a/info.go
+++ b/info.go
@@ -17,6 +17,8 @@ import (
 //
 // TODO: allow users to specify either topic names or topic IDs.
 func (c *Client) Info(ctx context.Context, topicIDs ...string) (info *api.ProjectInfo, err error) {
+	defer c.resetCallOpts()
+
 	req := &api.InfoRequest{
 		Topics: make([][]byte, 0, len(topicIDs)),
 	}
@@ -29,7 +31,7 @@ func (c *Client) Info(ctx context.Context, topicIDs ...string) (info *api.Projec
 		req.Topics = append(req.Topics, tid.Bytes())
 	}
 
-	if info, err = c.api.Info(ctx, req); err != nil {
+	if info, err = c.api.Info(ctx, req, c.copts...); err != nil {
 		// TODO: do a better job of categorizing the error
 		return nil, err
 	}

--- a/info.go
+++ b/info.go
@@ -29,10 +29,6 @@ func (c *Client) Info(ctx context.Context, topicIDs ...string) (info *api.Projec
 		req.Topics = append(req.Topics, tid.Bytes())
 	}
 
-	if c.api == nil {
-		panic("api is nil")
-	}
-
 	if info, err = c.api.Info(ctx, req, c.copts...); err != nil {
 		// TODO: do a better job of categorizing the error
 		return nil, err

--- a/info.go
+++ b/info.go
@@ -17,8 +17,6 @@ import (
 //
 // TODO: allow users to specify either topic names or topic IDs.
 func (c *Client) Info(ctx context.Context, topicIDs ...string) (info *api.ProjectInfo, err error) {
-	defer c.resetCallOpts()
-
 	req := &api.InfoRequest{
 		Topics: make([][]byte, 0, len(topicIDs)),
 	}
@@ -29,6 +27,10 @@ func (c *Client) Info(ctx context.Context, topicIDs ...string) (info *api.Projec
 			return nil, fmt.Errorf("could not parse %q as a topic id", topicID)
 		}
 		req.Topics = append(req.Topics, tid.Bytes())
+	}
+
+	if c.api == nil {
+		panic("api is nil")
 	}
 
 	if info, err = c.api.Info(ctx, req, c.copts...); err != nil {

--- a/topics.go
+++ b/topics.go
@@ -14,8 +14,10 @@ const DefaultPageSize uint32 = 100
 
 // Check if a topic with the specified name exists in the project or not.
 func (c *Client) TopicExists(ctx context.Context, topicName string) (_ bool, err error) {
+	defer c.resetCallOpts()
+
 	var info *api.TopicExistsInfo
-	if info, err = c.api.TopicExists(ctx, &api.TopicName{Name: topicName}); err != nil {
+	if info, err = c.api.TopicExists(ctx, &api.TopicName{Name: topicName}, c.copts...); err != nil {
 		return false, err
 	}
 	return info.Exists, nil
@@ -23,8 +25,10 @@ func (c *Client) TopicExists(ctx context.Context, topicName string) (_ bool, err
 
 // Create topic with the specified name and return the topic ID if there was no error.
 func (c *Client) CreateTopic(ctx context.Context, topic string) (_ string, err error) {
+	defer c.resetCallOpts()
+
 	var reply *api.Topic
-	if reply, err = c.api.CreateTopic(ctx, &api.Topic{Name: topic}); err != nil {
+	if reply, err = c.api.CreateTopic(ctx, &api.Topic{Name: topic}, c.copts...); err != nil {
 		// TODO: do a better job of categorizing the error
 		return "", err
 	}
@@ -39,6 +43,8 @@ func (c *Client) CreateTopic(ctx context.Context, topic string) (_ string, err e
 }
 
 func (c *Client) ListTopics(ctx context.Context) (topics []*api.Topic, err error) {
+	defer c.resetCallOpts()
+
 	// TODO: return an iterator rather than materializing all of the topics
 	topics = make([]*api.Topic, 0)
 	query := &api.PageInfo{PageSize: DefaultPageSize}
@@ -54,7 +60,7 @@ func (c *Client) ListTopics(ctx context.Context) (topics []*api.Topic, err error
 		}
 
 		// Make the topics page request
-		if page, err = c.api.ListTopics(ctx, query); err != nil {
+		if page, err = c.api.ListTopics(ctx, query, c.copts...); err != nil {
 			// TODO: do a better job of categorizing the error
 			return nil, err
 		}
@@ -80,6 +86,8 @@ func (c *Client) DestroyTopic(ctx context.Context, topicID string) (err error) {
 // Find a topic ID from a topic name.
 // TODO: automate and cache this on the client for easier lookups.
 func (c *Client) TopicID(ctx context.Context, topicName string) (_ string, err error) {
+	defer c.resetCallOpts()
+
 	// Create a base64 encoded murmur3 hash of the topic name
 	hash := murmur3.New128()
 	hash.Write([]byte(topicName))
@@ -90,7 +98,7 @@ func (c *Client) TopicID(ctx context.Context, topicName string) (_ string, err e
 	query := &api.PageInfo{PageSize: uint32(100)}
 
 	for page == nil || page.NextPageToken != "" {
-		if page, err = c.api.TopicNames(ctx, query); err != nil {
+		if page, err = c.api.TopicNames(ctx, query, c.copts...); err != nil {
 			return "", err
 		}
 

--- a/topics.go
+++ b/topics.go
@@ -14,8 +14,6 @@ const DefaultPageSize uint32 = 100
 
 // Check if a topic with the specified name exists in the project or not.
 func (c *Client) TopicExists(ctx context.Context, topicName string) (_ bool, err error) {
-	defer c.resetCallOpts()
-
 	var info *api.TopicExistsInfo
 	if info, err = c.api.TopicExists(ctx, &api.TopicName{Name: topicName}, c.copts...); err != nil {
 		return false, err
@@ -25,8 +23,6 @@ func (c *Client) TopicExists(ctx context.Context, topicName string) (_ bool, err
 
 // Create topic with the specified name and return the topic ID if there was no error.
 func (c *Client) CreateTopic(ctx context.Context, topic string) (_ string, err error) {
-	defer c.resetCallOpts()
-
 	var reply *api.Topic
 	if reply, err = c.api.CreateTopic(ctx, &api.Topic{Name: topic}, c.copts...); err != nil {
 		// TODO: do a better job of categorizing the error
@@ -43,8 +39,6 @@ func (c *Client) CreateTopic(ctx context.Context, topic string) (_ string, err e
 }
 
 func (c *Client) ListTopics(ctx context.Context) (topics []*api.Topic, err error) {
-	defer c.resetCallOpts()
-
 	// TODO: return an iterator rather than materializing all of the topics
 	topics = make([]*api.Topic, 0)
 	query := &api.PageInfo{PageSize: DefaultPageSize}
@@ -86,8 +80,6 @@ func (c *Client) DestroyTopic(ctx context.Context, topicID string) (err error) {
 // Find a topic ID from a topic name.
 // TODO: automate and cache this on the client for easier lookups.
 func (c *Client) TopicID(ctx context.Context, topicName string) (_ string, err error) {
-	defer c.resetCallOpts()
-
 	// Create a base64 encoded murmur3 hash of the topic name
 	hash := murmur3.New128()
 	hash.Write([]byte(topicName))


### PR DESCRIPTION
### Scope of changes

This PR adds per-call options to the Ensign client in as obtrusive a way as possible. I've added a function `WithCallOptions` that will ensure the next call has the specified options, then after that call the options are reset. This means that the Ensign client is no longer thread-safe, so I'm returning a clone of the client that should not be reused.

The usage idea is as follows:

```go
topics, err := client.WithCallOptions(auth.PerRPCToken("token", insecure)).ListTopics()
```

Fixes SC-16665

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Will this solve the per-call authentication issue with Tenant? Is this thread-safe? How do we mark this as experimental in the SDK documentation?

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [x]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?