### PR TITLE
Create SDK Specific Event Type

### DIFF
--- a/api/v1beta1/event.go
+++ b/api/v1beta1/event.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/proto"
@@ -29,4 +31,19 @@ func (w *EventWrapper) Unwrap() (e *Event, err error) {
 func (w *EventWrapper) ParseTopicID() (topicID ulid.ULID, err error) {
 	err = topicID.UnmarshalBinary(w.TopicId)
 	return topicID, err
+}
+
+func (t *Type) Version() string {
+	return fmt.Sprintf("%s v%d.%d.%d", t.Name, t.MajorVersion, t.MinorVersion, t.PatchVersion)
+}
+
+// Equals treats the name as case-insensitive.
+func (t *Type) Equals(o *Type) bool {
+	tname := strings.TrimSpace(strings.ToLower(t.Name))
+	oname := strings.TrimSpace(strings.ToLower(o.Name))
+
+	return (tname == oname &&
+		t.MajorVersion == o.MajorVersion &&
+		t.MinorVersion == o.MinorVersion &&
+		t.PatchVersion == o.PatchVersion)
 }

--- a/api/v1beta1/event_test.go
+++ b/api/v1beta1/event_test.go
@@ -42,3 +42,55 @@ func TestEventWrapper(t *testing.T) {
 	require.EqualError(t, err, "event wrapper contains no event")
 	require.Empty(t, empty, "no data event should be zero-valued")
 }
+
+func TestType(t *testing.T) {
+	car := &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8}
+	require.Equal(t, "car v1.4.8", car.Version())
+
+	// Equality checking
+	testCases := []struct {
+		alpha  *api.Type
+		bravo  *api.Type
+		assert require.BoolAssertionFunc
+	}{
+		{
+			alpha:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			bravo:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			assert: require.True,
+		},
+		{
+			alpha:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			bravo:  &api.Type{Name: "Car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			assert: require.True,
+		},
+		{
+			alpha:  &api.Type{Name: "CAR", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			bravo:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			assert: require.True,
+		},
+		{
+			alpha:  &api.Type{Name: " car ", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			bravo:  &api.Type{Name: "car ", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			assert: require.True,
+		},
+		{
+			alpha:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			bravo:  &api.Type{Name: "car", MajorVersion: 2, MinorVersion: 4, PatchVersion: 8},
+			assert: require.False,
+		},
+		{
+			alpha:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			bravo:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 9, PatchVersion: 8},
+			assert: require.False,
+		},
+		{
+			alpha:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 8},
+			bravo:  &api.Type{Name: "car", MajorVersion: 1, MinorVersion: 4, PatchVersion: 0},
+			assert: require.False,
+		},
+	}
+
+	for i, tc := range testCases {
+		tc.assert(t, tc.alpha.Equals(tc.bravo), "test case %d failed", i)
+	}
+}

--- a/ensign.go
+++ b/ensign.go
@@ -16,7 +16,7 @@ import (
 
 const BufferSize = 128
 
-// Client manages the credentials and connection to the ensign server.
+// Client manages the credentials and connection to the Ensign server.
 type Client struct {
 	sync.RWMutex
 	opts  Options
@@ -31,13 +31,13 @@ type Client struct {
 type Publisher interface {
 	io.Closer
 	Errorer
-	Publish(topic string, events ...*api.Event)
+	Publish(topic string, events ...*Event)
 }
 
 type Subscriber interface {
 	io.Closer
 	Errorer
-	Subscribe() (<-chan *api.Event, error)
+	Subscribe() (<-chan *Event, error)
 	Ack(id []byte) error
 	Nack(id []byte, err error) error
 }
@@ -180,7 +180,7 @@ func (c *Client) Publish(ctx context.Context) (_ Publisher, err error) {
 func (c *Client) Subscribe(ctx context.Context, topics ...string) (_ Subscriber, err error) {
 	sub := &subscriber{
 		send: make(chan *api.SubscribeRequest, BufferSize),
-		recv: make([]chan<- *api.Event, 0, 1),
+		recv: make([]chan<- *Event, 0, 1),
 		stop: make(chan struct{}, 1),
 		errc: make(chan error, 1),
 	}

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,11 @@
 package ensign
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+
+	api "github.com/rotationalio/go-ensign/api/v1beta1"
+)
 
 var (
 	ErrMissingEndpoint     = errors.New("invalid options: endpoint is required")
@@ -10,8 +15,31 @@ var (
 	ErrMissingMock         = errors.New("invalid options: in testing mode a mock grpc server is required")
 	ErrTopicNameNotFound   = errors.New("topic name not found in project")
 	ErrStreamUninitialized = errors.New("could not initialize stream with server")
+	ErrCannotAck           = errors.New("cannot ack or nack an event not received from subscribe")
+	ErrOverwrite           = errors.New("this operation would overwrite existing event data")
 )
 
 type Errorer interface {
 	Err() error
+}
+
+type NackError struct {
+	ID      []byte
+	Code    api.Nack_Code
+	Message string
+}
+
+func (e *NackError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("[%s] %s", e.Code.String(), e.Message)
+	}
+	return e.Code.String()
+}
+
+func makeNackError(nack *api.Nack) error {
+	return &NackError{
+		ID:      nack.Id,
+		Code:    nack.Code,
+		Message: nack.Error,
+	}
 }

--- a/event.go
+++ b/event.go
@@ -1,6 +1,10 @@
 package ensign
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
 	"time"
 
 	api "github.com/rotationalio/go-ensign/api/v1beta1"
@@ -16,11 +20,6 @@ import (
 // using the Ensign schema registry and use those types to create events to publish and
 // subscribe/query from.
 type Event struct {
-	// Users can specify an ID that can be used locally for tracking the event but
-	// cannot be used globally accross multiple publishers and subscribers. This ID is
-	// empty by default and not used by Ensign except for logging and debugging.
-	LocalID string
-
 	// Metadata are user-defined key/value pairs that can be optionally added to an
 	// event to store/lookup data without unmarshaling the entire payload.
 	Metadata Metadata
@@ -36,44 +35,248 @@ type Event struct {
 
 	// Created is the timestamp that the event was created according to the client clock.
 	Created time.Time
+
+	// Internal fields used for managing the event through the publish or subscribe
+	// workflows. The goal of the public facing parts of the event is to give the user
+	// an easy tool to work with events while abstracting Ensign eventing details.
+	mu    sync.Mutex
+	state eventState
+	info  *api.EventWrapper
+	ctx   context.Context
+	err   error
+	pub   <-chan *api.PublisherReply
+	sub   chan<- *api.SubscribeRequest
+}
+
+// Acked allows a user to check if an event published to an event stream has been
+// successfully received by the server.
+func (e *Event) Acked() (bool, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Check the publisher reply stream to see if an ack or nack has been received.
+	if e.state == published {
+		e.checkpub()
+	}
+
+	return e.state == acked, e.err
+}
+
+// Nacked allows a user to check if an event published to an event stream has errored or
+// otherwise been rejected by the server.
+func (e *Event) Nacked() (bool, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Check the publisher reply stream to see if an ack or nack has been received.
+	if e.state == published {
+		e.checkpub()
+	}
+
+	return e.state == nacked, e.err
+}
+
+func (e *Event) checkpub() {
+	select {
+	case rep := <-e.pub:
+		switch msg := rep.Embed.(type) {
+		case *api.PublisherReply_Ack:
+			e.state = acked
+			e.info.Committed = msg.Ack.Committed
+		case *api.PublisherReply_Nack:
+			e.state = nacked
+			e.err = makeNackError(msg.Nack)
+		default:
+			e.err = fmt.Errorf("unhandled publisher reply %T", rep.Embed)
+		}
+	default:
+	}
+}
+
+// Ack allows a user to acknowledge back to the Ensign server that an event received by
+// a subscription stream has been successfully consumed. For consumer groups that have
+// exactly-once or at-least-once semantics, this signals the message has been delivered
+// successfully so as to not trigger a redelivery of the message to another consumer.
+// Ack does not block and returns true if already acked. If a nack was sent before ack,
+// then this method returns false. If this event was not received on a subscribe stream
+// then an error is returned.
+func (e *Event) Ack() (bool, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	switch e.state {
+	case acked:
+		return true, e.err
+	case nacked:
+		return false, e.err
+	case initialized, published:
+		return false, ErrCannotAck
+	}
+
+	// Send the ack on the sub channel to be sent back to the Ensign server?
+	e.sub <- &api.SubscribeRequest{
+		Embed: &api.SubscribeRequest_Ack{
+			Ack: &api.Ack{
+				Id: e.info.Id,
+			},
+		},
+	}
+
+	// TODO: what happens if the ack message cannot be sent?
+	e.state = acked
+	return true, nil
+}
+
+// Nack allows a user to signal to the Ensign server that an event received by a
+// subscription stream has not been successfully consumed. For consumer groups that have
+// exactly-once or at-least-once semantics, this signals the message needs to be
+// redelivered to another consumer.
+//
+// Nack does not block and returns true if already nacked. If an ack was sent before
+// the nack, then this method returns false. If this event was not received on a
+// subscribe stream then an error is returned.
+func (e *Event) Nack(code api.Nack_Code) (bool, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	switch e.state {
+	case nacked:
+		return true, e.err
+	case acked:
+		return false, e.err
+	case initialized, published:
+		return false, ErrCannotAck
+	}
+
+	// Send the ack on the sub channel to be sent back to the Ensign server?
+	e.sub <- &api.SubscribeRequest{
+		Embed: &api.SubscribeRequest_Nack{
+			Nack: &api.Nack{
+				Id:   e.info.Id,
+				Code: code,
+			},
+		},
+	}
+
+	// TODO: what happens if the ack message cannot be sent?
+	e.state = acked
+	return true, nil
+}
+
+// Err returns any error that occurred processing the event.
+func (e *Event) Err() error {
+	return e.err
+}
+
+// Context returns the message context if set otherwise a background context.
+func (e *Event) Context() context.Context {
+	if e.ctx != nil {
+		return e.ctx
+	}
+	return context.Background()
+}
+
+// SetContext provides an event context for use in the handling application.
+func (e *Event) SetContext(ctx context.Context) {
+	e.ctx = ctx
+}
+
+// Clone the event, resetting its state and removing acks, nacks, created timestamp and
+// context. Useful for resending events or for duplicating an event to edit and publish.
+func (e *Event) Clone() *Event {
+	event := &Event{
+		Metadata: make(Metadata),
+		Data:     make([]byte, 0, len(e.Data)),
+		Mimetype: e.Mimetype,
+		Type:     e.Type,
+		state:    initialized,
+	}
+
+	// Copy the metadata
+	for key, val := range e.Metadata {
+		event.Metadata[key] = val
+	}
+
+	// Copy the data
+	copy(event.Data, e.Data)
+
+	return event
+}
+
+// Compare two events to determine if they are equivalent by data.
+// See Same() to determine if they are the same event by offset/topic.
+func (e *Event) Equals(o *Event) bool {
+	// Compare mimetype
+	if e.Mimetype != o.Mimetype {
+		return false
+	}
+
+	// Compare type
+	if !e.Type.Equals(o.Type) {
+		return false
+	}
+
+	// Compare created at timestamp
+	if !e.Created.Equal(o.Created) {
+		return false
+	}
+
+	// Compare metadata
+	if len(e.Metadata) != len(o.Metadata) {
+		return false
+	}
+
+	for key, val := range e.Metadata {
+		if o.Metadata[key] != val {
+			return false
+		}
+	}
+
+	// Compare raw data payload
+	return bytes.Equal(e.Data, o.Data)
 }
 
 // Convert an event into a protocol buffer event.
 func (e *Event) toPB() *api.Event {
 	return &api.Event{
-		UserDefinedId: e.LocalID,
-		Data:          e.Data,
-		Metadata:      map[string]string(e.Metadata),
-		Mimetype:      e.Mimetype,
-		Type:          e.Type,
-		Created:       timestamppb.New(e.Created),
+		Data:     e.Data,
+		Metadata: map[string]string(e.Metadata),
+		Mimetype: e.Mimetype,
+		Type:     e.Type,
+		Created:  timestamppb.New(e.Created),
 	}
 }
 
 // Convert a protocol buffer event into this event.
-func (e *Event) fromPB(event *api.Event) {
-	e.LocalID = event.UserDefinedId
+func (e *Event) fromPB(wrapper *api.EventWrapper, state eventState) (err error) {
+	if e.state != initialized {
+		return ErrOverwrite
+	}
+
+	// Set info on the wrapper
+	e.info = wrapper
+
+	var event *api.Event
+	if event, err = wrapper.Unwrap(); err != nil {
+		return err
+	}
+
 	e.Data = event.Data
 	e.Metadata = Metadata(event.Metadata)
 	e.Mimetype = event.Mimetype
 	e.Type = event.Type
 	e.Created = event.Created.AsTime()
+	e.state = state
+
+	return nil
 }
 
-// Metadata are user-defined key/value pairs that can be optionally added to an
-// event to store/lookup data without unmarshaling the entire payload.
-type Metadata map[string]string
+type eventState uint8
 
-// Get returns the metadata value for the given key. If the key is not in the metadata
-// an empty string is returned without an error.
-func (m Metadata) Get(key string) string {
-	if val, ok := m[key]; ok {
-		return val
-	}
-	return ""
-}
-
-// Set a metadata value for the given key; overwrites existing keys.
-func (m Metadata) Set(key, value string) {
-	m[key] = value
-}
+const (
+	initialized  eventState = iota // event has been created but hasn't been published
+	published                      // event has been published, awaiting ack from server
+	subscription                   // event has been received from subscription, awaiting ack from user
+	acked                          // event has been acked from user or server
+	nacked                         // event has been nacked from user or server
+)

--- a/event.go
+++ b/event.go
@@ -1,0 +1,79 @@
+package ensign
+
+import (
+	"time"
+
+	api "github.com/rotationalio/go-ensign/api/v1beta1"
+	mimetype "github.com/rotationalio/go-ensign/mimetype/v1beta1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Events wrap user-defined datagrams that are totally ordered by the Ensign platform.
+// Publishers create events with arbitrary data and send them to Ensign so that they can
+// be sent to Subscribers awaiting the events or queried using EnSQL for later
+// consumption. The datagram the event wraps is user-specific. It can be JSON, msgpack,
+// text data, parquet, protocol buffers, etc. Applications should define event types
+// using the Ensign schema registry and use those types to create events to publish and
+// subscribe/query from.
+type Event struct {
+	// Users can specify an ID that can be used locally for tracking the event but
+	// cannot be used globally accross multiple publishers and subscribers. This ID is
+	// empty by default and not used by Ensign except for logging and debugging.
+	LocalID string
+
+	// Metadata are user-defined key/value pairs that can be optionally added to an
+	// event to store/lookup data without unmarshaling the entire payload.
+	Metadata Metadata
+
+	// Data is the datagram payload that defines the event.
+	Data []byte
+
+	// Mimetype describes how to parse the event datagram.
+	Mimetype mimetype.MIME
+
+	// Type defines the schema of the event datagram and is optional.
+	Type *api.Type
+
+	// Created is the timestamp that the event was created according to the client clock.
+	Created time.Time
+}
+
+// Convert an event into a protocol buffer event.
+func (e *Event) toPB() *api.Event {
+	return &api.Event{
+		UserDefinedId: e.LocalID,
+		Data:          e.Data,
+		Metadata:      map[string]string(e.Metadata),
+		Mimetype:      e.Mimetype,
+		Type:          e.Type,
+		Created:       timestamppb.New(e.Created),
+	}
+}
+
+// Convert a protocol buffer event into this event.
+func (e *Event) fromPB(event *api.Event) {
+	e.LocalID = event.UserDefinedId
+	e.Data = event.Data
+	e.Metadata = Metadata(event.Metadata)
+	e.Mimetype = event.Mimetype
+	e.Type = event.Type
+	e.Created = event.Created.AsTime()
+}
+
+// Metadata are user-defined key/value pairs that can be optionally added to an
+// event to store/lookup data without unmarshaling the entire payload.
+type Metadata map[string]string
+
+// Get returns the metadata value for the given key. If the key is not in the metadata
+// an empty string is returned without an error.
+func (m Metadata) Get(key string) string {
+	if val, ok := m[key]; ok {
+		return val
+	}
+	return ""
+}
+
+// Set a metadata value for the given key; overwrites existing keys.
+func (m Metadata) Set(key, value string) {
+	m[key] = value
+}

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,1 @@
+package ensign_test

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,19 @@
+package ensign
+
+// Metadata are user-defined key/value pairs that can be optionally added to an
+// event to store/lookup data without unmarshaling the entire payload.
+type Metadata map[string]string
+
+// Get returns the metadata value for the given key. If the key is not in the metadata
+// an empty string is returned without an error.
+func (m Metadata) Get(key string) string {
+	if val, ok := m[key]; ok {
+		return val
+	}
+	return ""
+}
+
+// Set a metadata value for the given key; overwrites existing keys.
+func (m Metadata) Set(key, value string) {
+	m[key] = value
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,16 @@
+package ensign_test
+
+import (
+	"testing"
+
+	"github.com/rotationalio/go-ensign"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadata(t *testing.T) {
+	meta := make(ensign.Metadata)
+	require.Empty(t, meta.Get("key"), "expected empty string when key doesn't exist")
+
+	meta.Set("key", "value")
+	require.Equal(t, "value", meta.Get("key"), "should be able to get and set key/value pair")
+}

--- a/publisher.go
+++ b/publisher.go
@@ -19,7 +19,7 @@ type publisher struct {
 
 var _ Publisher = &publisher{}
 
-func (c *publisher) Publish(topic string, events ...*api.Event) {
+func (c *publisher) Publish(topic string, events ...*Event) {
 	// TODO: handle topic name mapping and topic manager
 	// TODO: better error handling
 	topicID, _ := ulid.Parse(topic)
@@ -31,7 +31,7 @@ func (c *publisher) Publish(topic string, events ...*api.Event) {
 		}
 
 		// TODO: handle errors
-		env.Wrap(event)
+		env.Wrap(event.toPB())
 
 		c.send <- env
 	}

--- a/subscriber.go
+++ b/subscriber.go
@@ -108,8 +108,12 @@ func (c *subscriber) recver() {
 		}
 
 		// Convert the event into an API event
+		// TODO: handle the subscribe request channel
 		event := &Event{}
-		event.fromPB(wrapper, subscription)
+		if _, err := event.fromPB(wrapper, subscription); err != nil {
+			// TODO: what to do about the error?
+			panic(err)
+		}
 
 		c.RLock()
 		for _, sub := range c.recv {

--- a/subscriber.go
+++ b/subscriber.go
@@ -102,18 +102,14 @@ func (c *subscriber) recver() {
 
 		// Fetch the event from the subscribe reply
 		// TODO: handle other message types such as close stream
-		var evt *api.Event
-		if wrapper := e.GetEvent(); evt != nil {
-			evt, _ = wrapper.Unwrap()
-		}
-
-		if evt == nil {
+		var wrapper *api.EventWrapper
+		if wrapper = e.GetEvent(); wrapper == nil {
 			continue
 		}
 
 		// Convert the event into an API event
 		event := &Event{}
-		event.fromPB(evt)
+		event.fromPB(wrapper, subscription)
 
 		c.RLock()
 		for _, sub := range c.recv {


### PR DESCRIPTION
### Scope of changes

Creates an SDK specific event type so that users aren't directly using the protocol buffer generated type. 

Fixes SC-16139

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.