### PR TITLE
Adds user agent to dial options

### DIFF
--- a/ensign.go
+++ b/ensign.go
@@ -3,6 +3,7 @@ package ensign
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"sync"
 	"time"
 
@@ -22,6 +23,9 @@ const (
 
 	// The default page size for paginated gRPC responses.
 	DefaultPageSize = uint32(100)
+
+	// The Go SDK user agent format string.
+	UserAgent = "Ensign Go SDK/v%d"
 )
 
 // Client manages the credentials and connection to the Ensign server. The New() method
@@ -79,7 +83,7 @@ func New(opts ...Option) (client *Client, err error) {
 
 func (c *Client) connect() (err error) {
 	// Fetch the dialing options from the ensign config.
-	opts := make([]grpc.DialOption, 0, 3)
+	opts := make([]grpc.DialOption, 0, 4)
 	opts = append(opts, c.opts.Dialing...)
 
 	// If no dialing opts were specified create default dialing options.
@@ -102,6 +106,9 @@ func (c *Client) connect() (err error) {
 			opts = append(opts, grpc.WithUnaryInterceptor(c.auth.UnaryAuthenticate))
 			opts = append(opts, grpc.WithStreamInterceptor(c.auth.StreamAuthenticate))
 		}
+
+		// Add the user agent to the options
+		opts = append(opts, grpc.WithUserAgent(fmt.Sprintf(UserAgent, VersionMajor)))
 	}
 
 	if c.cc, err = grpc.Dial(c.opts.Endpoint, opts...); err != nil {


### PR DESCRIPTION
### Scope of changes

Adds user agent to the meta data via the dial options so that it can be recorded in the publisher details. We should do something similar in the Python SDK.

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Can this be replicated to the Python SDK?

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?